### PR TITLE
Add FMODGMS_Chan_Is_Playing to vc/linux sources

### DIFF
--- a/src/linux/fmodgms.cpp
+++ b/src/linux/fmodgms.cpp
@@ -1587,6 +1587,33 @@ GMexport double FMODGMS_Chan_Get_Mute(double channel)
 	}
 }
 
+// Checks if the given channel is currently playing a sound
+GMexport double FMODGMS_Chan_Is_Playing(double channel)
+{
+	int c = (int)round(channel);
+	int chanListSize = channelList.size();
+	
+	if (chanListSize > c && c >= 0)
+	{
+		bool playing;
+		if (channelList[c]->isPlaying(&playing) == FMOD_OK)
+		{
+			return (double)playing;
+		}
+		else
+		{
+			errorMessage = "Could not get playing status";
+			return GMS_false;
+		}
+	}
+	// index out of bounds
+	else
+	{
+		errorMessage = "Index out of bounds.";
+		return GMS_error;
+	}
+}
+
 //Adds an effect e to the i-th index of effect chain of a channel
 GMexport double FMODGMS_Chan_Add_Effect(double channel, double e, double i)
 {

--- a/src/linux/fmodgms.hpp
+++ b/src/linux/fmodgms.hpp
@@ -101,6 +101,7 @@ GMexport double FMODGMS_Chan_Get_ModOrder(double channel);
 GMexport double FMODGMS_Chan_Get_ModPattern(double channel);
 GMexport double FMODGMS_Chan_Get_ModRow(double channel);
 GMexport double FMODGMS_Chan_Get_Mute(double channel);
+GMexport double FMODGMS_Chan_Is_Playing(double channel);
 GMexport double FMODGMS_Chan_Add_Effect(double channel, double effect, double index);
 GMexport double FMODGMS_Chan_Remove_Effect(double channel, double effect);
 GMexport double FMODGMS_Chan_Get_Level(double channel);

--- a/src/vc/FMODGMS/FMODGMS/fmodgms.cpp
+++ b/src/vc/FMODGMS/FMODGMS/fmodgms.cpp
@@ -1551,6 +1551,31 @@ GMexport double FMODGMS_Chan_Get_Mute(double channel)
 	}
 }
 
+// Checks if the given channel is currently playing a sound
+GMexport double FMODGMS_Chan_Is_Playing(double channel)
+{
+	std::size_t c = (std::size_t)round(channel);
+	if (channelList.count(c) == 1)
+	{
+		bool playing;
+		if (channelList[c]->isPlaying(&playing) == FMOD_OK)
+		{
+			return (double)playing;
+		}
+		else
+		{
+			errorMessage = "Could not get playing status";
+			return GMS_false;
+		}
+	}
+	// index out of bounds
+	else
+	{
+		errorMessage = "Index out of bounds.";
+		return GMS_error;
+	}
+}
+
 //Adds an effect e to the i-th index of effect chain of a channel
 GMexport double FMODGMS_Chan_Add_Effect(double channel, double e, double i)
 {

--- a/src/vc/FMODGMS/FMODGMS/fmodgms.hpp
+++ b/src/vc/FMODGMS/FMODGMS/fmodgms.hpp
@@ -101,6 +101,7 @@ GMexport double FMODGMS_Chan_Get_ModOrder(double channel);
 GMexport double FMODGMS_Chan_Get_ModPattern(double channel);
 GMexport double FMODGMS_Chan_Get_ModRow(double channel);
 GMexport double FMODGMS_Chan_Get_Mute(double channel);
+GMexport double FMODGMS_Chan_Is_Playing(double channel);
 GMexport double FMODGMS_Chan_Add_Effect(double channel, double effect, double index);
 GMexport double FMODGMS_Chan_Remove_Effect(double channel, double effect);
 GMexport double FMODGMS_Chan_Get_Level(double channel);


### PR DESCRIPTION
Adds support for checking playing status of a channel within the extension to the vc and linux sources. FMOD already had this as a feature, it was just a matter of implementing the wrapper functions accordingly.

Tested on Windows 7, not tested on Linux or Windows 10 (the default branch settings for the vc project) but I don't see why it shouldn't work. 

Will defer the decision of alterations to GMS example projects to the project creator. @mstop4 thank you for making the source generally easy to read and compile on Windows. 